### PR TITLE
Fix checks for correct number of arguments in the examples

### DIFF
--- a/examples/compression_comparison.cpp
+++ b/examples/compression_comparison.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
     MPI_Init(&argc, &argv);
 
     // Check the number of parameters
-    if (argc < 3) {
+    if (argc != 4) {
         // Tell the user how to run the program
         cerr << "Usage: " << argv[0] << " distance \b outputfile \b outputpath" << endl;
         /* "Usage messages" are a conventional way of telling the user

--- a/examples/use_clustering.cpp
+++ b/examples/use_clustering.cpp
@@ -9,7 +9,7 @@ using namespace htool;
 int main(int argc, char *argv[]) {
 
     // Check the number of parameters
-    if (argc < 1) {
+    if (argc != 2) {
         // Tell the user how to run the program
         cerr << "Usage: " << argv[0] << "  outputname" << endl;
         /* "Usage messages" are a conventional way of telling the user

--- a/examples/use_distributed_operator.cpp
+++ b/examples/use_distributed_operator.cpp
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
     MPI_Comm_size(MPI_COMM_WORLD, &sizeWorld);
 
     // Check the number of parameters
-    if (argc < 1) {
+    if (argc != 2) {
         // Tell the user how to run the program
         cerr << "Usage: " << argv[0] << " outputpath" << endl;
         /* "Usage messages" are a conventional way of telling the user

--- a/examples/use_hmatrix.cpp
+++ b/examples/use_hmatrix.cpp
@@ -59,7 +59,7 @@ class UserOperator : public VirtualGenerator<double> {
 int main(int argc, char *argv[]) {
 
     // Check the number of parameters
-    if (argc < 1) {
+    if (argc != 2) {
         // Tell the user how to run the program
         cerr << "Usage: " << argv[0] << " outputpath" << endl;
         /* "Usage messages" are a conventional way of telling the user


### PR DESCRIPTION
Some of the examples use wrong numbers in the if that checks for the correct number of command line arguments.